### PR TITLE
Add functional test for /about path

### DIFF
--- a/tests/Feature/AboutPageTest.php
+++ b/tests/Feature/AboutPageTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class AboutPageTest extends TestCase
+{
+    /**
+     * Test that the about page returns a successful response and correct content.
+     *
+     * @return void
+     */
+    public function test_about_page_returns_successful_response()
+    {
+        $response = $this->get('/about');
+
+        $response->assertStatus(200);
+        $response->assertSee("This is the About page.");
+    }
+}


### PR DESCRIPTION
This commit introduces a new feature test for the /about page. The test verifies that the page returns a 200 OK status and that it contains the expected text "This is the About page.".