### PR TITLE
feat: Add AboutController for the about page

### DIFF
--- a/app/Http/Controllers/AboutController.php
+++ b/app/Http/Controllers/AboutController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class AboutController extends Controller
+{
+    /**
+     * Display the about page.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function index()
+    {
+        return view('about');
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,12 +2,11 @@
 
 use App\Http\Controllers\ProductController;
 use App\Http\Controllers\HomeController;
+use App\Http\Controllers\AboutController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', [HomeController::class, 'index']);
 
-Route::get('/about', function () {
-    return view('about');
-});
+Route::get('/about', [AboutController::class, 'index'])->name('about');
 
 Route::get('/products', [ProductController::class, 'index'])->name('products.index');


### PR DESCRIPTION
I've created a new `AboutController` to handle requests for the `/about` route. The controller's `index` method returns the 'about' view.

I've updated `routes/web.php` to use `AboutController@index` for the `/about` route, replacing the previous closure-based route.

I confirmed that the existing tests in `tests/Feature/AboutPageTest.php` pass with the new controller setup.